### PR TITLE
Fix cross-origin dev config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Vicre Next.js App
+
+This project is a basic Next.js application used for testing Azure AD login via **MSAL** and interacting with Supabase. Environment variables are used to configure authentication and API access.
+
+## Environment Variables
+Create a `.env.local` file in `app-main/` with the following variables:
+
+```bash
+NEXT_PUBLIC_AZURE_AD_CLIENT_ID=<Azure AD application (client) ID>
+NEXT_PUBLIC_AZURE_AD_TENANT_ID=<Azure AD tenant ID>
+NEXT_PUBLIC_AZURE_AD_REDIRECT_URI=<redirect URI registered as a SPA>
+
+NEXT_PUBLIC_SUPABASE_URL=<Supabase project URL>
+NEXT_PUBLIC_SUPABASE_ANON=<Supabase anon key>
+SUPABASE_SERVICE_KEY=<Supabase service role key>
+
+MY_SECRET_API_KEY=<API key required by middleware>
+SECRET_API_KEY=<API key used by lib/authenticate.js>
+```
+
+Additional variables may be required for specific API routes. Refer to the files under `pages/api/` for details.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+cd app-main
+npm install
+npm run dev
+```
+
+During development the app uses an ngrok domain. `next.config.js` allows requests from `https://dtuaitsoc.ngrok.dev` so that cross‑origin warnings are suppressed.

--- a/app-main/next.config.js
+++ b/app-main/next.config.js
@@ -1,5 +1,9 @@
 // next.config.js
 module.exports = {
+  experimental: {
+    // Allow ngrok domain during development for cross-origin requests
+    allowedDevOrigins: ['https://dtuaitsoc.ngrok.dev'],
+  },
   webpack: (config, { dev }) => {
     if (!dev) {
       // Only modify 'devtool' in production

--- a/app-main/package.json
+++ b/app-main/package.json
@@ -10,7 +10,8 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "debug": "NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev"
+        "debug": "NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev",
+        "lint": "eslint ."
     },
     "dependencies": {
         "@azure/cosmos": "^4.2.0",
@@ -31,6 +32,7 @@
         "concurrently": "^9.1.0",
         "postcss": "^8.4.40",
         "tailwindcss": "^3.4.7",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "eslint": "^8.56.0"
     }
 }


### PR DESCRIPTION
## Summary
- allow ngrok domain during development
- document required environment variables
- add eslint script

## Testing
- `npm run lint` *(fails: couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_683f02c4df00832c93accbdea2ea19ea