### PR TITLE
Remove DTU logo

### DIFF
--- a/app-main/lib/emailTemplates/partials/header.html
+++ b/app-main/lib/emailTemplates/partials/header.html
@@ -28,14 +28,6 @@
                             <table width="100%" style="border-collapse: collapse;">
                                 <tr>
                                     <td valign="middle" width="50">
-                                        <!-- DTU LOGO -->
-                                        <img 
-                                            src="https://api.supabase.coolify01.azure.dtu.reipur.dk/storage/v1/object/public/dtu-design/white-dtu-logo-36-53.png" 
-                                            alt="DTU Logo" 
-                                            width="36" 
-                                            height="53"
-                                            style="display: block; width: 36px; height: 53px;" 
-                                        />
                                     </td>
                                     <td style="vertical-align: middle; text-align: right;">
                                         <h2 style="


### PR DESCRIPTION
## Summary
- remove DTU logo `<img>` from the email template header

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_685aa37b1530832c88911a24c898c29d